### PR TITLE
msm8996-common: wifi: Restore previous WiFi offload setting

### DIFF
--- a/wifi/WCNSS_qcom_cfg.ini
+++ b/wifi/WCNSS_qcom_cfg.ini
@@ -451,7 +451,7 @@ gFlexConnectPowerFactor=0
 gNumChanCombinedConc=60
 
 #Enable Power Save offload
-gEnablePowerSaveOffload=5
+gEnablePowerSaveOffload=1
 
 #Enable firmware uart print
 gEnablefwprint=0


### PR DESCRIPTION
* May fix issues with:
  - Random reboots,
  - WiFi not letting device deep sleep,
  - WiFi randomly disconnecting.

Change-Id: I6074bf89a20b5bfc3d8bc79e419496498154cd47